### PR TITLE
Revert j2n6s300_standalone.xacro to its original version

### DIFF
--- a/kinova_description/urdf/j2n6s300_standalone.xacro
+++ b/kinova_description/urdf/j2n6s300_standalone.xacro
@@ -18,11 +18,6 @@
 
 
   <xacro:include filename="$(find kinova_description)/urdf/j2n6s300.xacro"/>
-     
-  <xacro:property name="camera_link" value="0.05" />
-  <xacro:property name="height_camera" value="0.157"/>
-  <xacro:property name="axel_offset" value="0.05"/>
-  <xacro:property name="camera_mesh" value="Genie_Nano"/>
 
   <link name="root">
     <visual>
@@ -53,36 +48,5 @@
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2n6s300  base_parent="${robot_root}"/>
-
-  <!-- for camera sensor -->
-  <joint name="camera_joint" type="fixed">
-    <axis xyz="0 1 0" />
-    <origin xyz="${camera_link} 0 ${height_camera - axel_offset*2}" rpy="0 0 0"/>
-    <parent link="j2n6s300_link_6"/>
-    <child link="camera_link"/>
-  </joint>
-
-  <link name="camera_link">
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <geometry>
-        <mesh filename="package://kinova_description/meshes/${camera_mesh}.dae"/>
-      </geometry>
-    </collision>
-
-    <visual>
-      <origin xyz="0 0 0" rpy="1.5707 0 -1.5707"/>
-      <geometry>
-        <mesh filename="package://kinova_description/meshes/${camera_mesh}.dae"/>
-      </geometry>
-      <material name="red"/>
-    </visual>
-
-    <inertial>
-      <mass value="1e-5" />
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <inertia ixx="1e-6" ixy="0" ixz="0" iyy="1e-6" iyz="0" izz="1e-6" />
-    </inertial>
-  </link>
 
 </robot>


### PR DESCRIPTION
Marco, fiz essa correção no description do j2n6s300 para voltar ele a como estava no repositorio do kinova. Durante o desenvolvimento dos desafios do programa de estágio, eu os alterei adicionando o link da camera com a teledyne. Deixarei essa configuração teledyne+arm no repositório do jaco_b, só por registro e caso precise usar a teledyne no futuro. 